### PR TITLE
fix: 修正tmp.yaml(h5s视频平台)

### DIFF
--- a/fingers/http/tmp.yaml
+++ b/fingers/http/tmp.yaml
@@ -12193,7 +12193,7 @@
   rule:
     - regexps:
         body:
-          - h5s视频平台|web
+          - h5s视频平台
 - name: ZKTime
   link: http://xqy.huidechina.com:9090/accounts/login/?next=/data/index/
   rule:


### PR DESCRIPTION
h5s视频平台|web 修改为 h5s视频平台，减少误报
```
 - h5s视频平台|web
```
修改为
```
 - h5s视频平台
```